### PR TITLE
Resize band photos upon upload

### DIFF
--- a/harmonics-ui/package-lock.json
+++ b/harmonics-ui/package-lock.json
@@ -29,12 +29,14 @@
         "axios": "^1.13.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-image-crop": "^11.0.10",
         "react-router": "^7.13.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/offscreencanvas": "^2019.7.3",
         "postcss": "^8.5.6",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1"
@@ -3929,6 +3931,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -14158,6 +14167,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/harmonics-ui/package.json
+++ b/harmonics-ui/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.13.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-image-crop": "^11.0.10",
     "react-router": "^7.13.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
@@ -55,6 +56,7 @@
     ]
   },
   "devDependencies": {
+    "@types/offscreencanvas": "^2019.7.3",
     "postcss": "^8.5.6",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1"

--- a/harmonics-ui/src/components/bands/BandCover.tsx
+++ b/harmonics-ui/src/components/bands/BandCover.tsx
@@ -18,7 +18,7 @@ export const BandCover = ({ band }: BandCoverProps) => {
       onClick={() => navigate(`/bands/${band.name}`)}
     >
       <Card.Section>
-        <Image src={`/static/${band.name}`} height={160} alt={band.name} />
+        <Image src={`/static/${band.name}`} h="100%" alt={band.name} />
       </Card.Section>
 
       <Space h="xs" />

--- a/harmonics-ui/src/forms/bands/BandProfileCropper.tsx
+++ b/harmonics-ui/src/forms/bands/BandProfileCropper.tsx
@@ -1,0 +1,101 @@
+import { FileWithPath } from "@mantine/dropzone";
+import { ReactEventHandler, useEffect, useRef, useState } from "react";
+import ReactCrop, { centerCrop, Crop, makeAspectCrop } from "react-image-crop";
+import { Button, Image } from "@mantine/core";
+import "react-image-crop/dist/ReactCrop.css";
+
+interface BandProfileCropperProps {
+  file?: FileWithPath;
+  setCroppedFile: (f: File) => void;
+}
+
+export const BandProfileCropper = ({
+  file,
+  setCroppedFile,
+}: BandProfileCropperProps) => {
+  const [crop, setCrop] = useState<Crop>();
+  const [image, setImage] = useState<string>("");
+  const [originalHeight, setOriginalHeight] = useState(0);
+  const [originalWidth, setOriginalWidth] = useState(0);
+  const imageRef = useRef<HTMLImageElement | null>(null);
+
+  const onImageLoad: ReactEventHandler<HTMLImageElement> = (e) => {
+    const { naturalWidth: width, naturalHeight: height } = e.currentTarget;
+    setOriginalWidth(width);
+    setOriginalHeight(height);
+
+    const crop = centerCrop(
+      makeAspectCrop(
+        {
+          unit: "%",
+          width: 100,
+        },
+        1,
+        width,
+        height,
+      ),
+      width,
+      height,
+    );
+
+    setCrop(crop);
+  };
+
+  useEffect(() => {
+    if (file) {
+      setImage(URL.createObjectURL(file));
+    }
+  }, [file]);
+
+  // Adjust file when crop changes
+  useEffect(() => {
+    if (crop && file) {
+      if (imageRef.current) {
+        const offscreen = new OffscreenCanvas(640, 640);
+
+        // Calculate crop position from top left
+        const cropX = (crop.x / 100) * originalWidth;
+        const cropY = (crop.y / 100) * originalHeight;
+
+        // Original image crop
+        const originalCropWidth = (crop.width / 100) * originalWidth;
+        const originalCropHeight = (crop.height / 100) * originalHeight;
+
+        (
+          offscreen.getContext("2d") as OffscreenCanvasRenderingContext2D
+        )?.drawImage(
+          imageRef.current,
+          cropX,
+          cropY,
+          originalCropWidth,
+          originalCropHeight,
+          0,
+          0,
+          640,
+          640,
+        );
+
+        offscreen
+          .convertToBlob({
+            type: "image/jpeg",
+            quality: 1,
+          })
+          .then((b) => {
+            setCroppedFile(new File([b], file.name));
+          });
+      }
+    }
+  }, [crop]);
+
+  if (!file) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <ReactCrop crop={crop} onChange={(_, c) => setCrop(c)} aspect={1}>
+        <Image src={image} ref={imageRef} onLoad={onImageLoad} />
+      </ReactCrop>
+    </>
+  );
+};

--- a/harmonics-ui/src/types/band.tsx
+++ b/harmonics-ui/src/types/band.tsx
@@ -1,9 +1,8 @@
-import { FileWithPath } from "@mantine/dropzone";
 import { Genre } from "./genre";
 
 export interface Band {
   name: string;
   genres: Genre[];
-  img?: FileWithPath;
+  img?: File;
   recommendations: Band[];
 }


### PR DESCRIPTION
This restricts users to a square crop, and then resizes that to 640x640 (twice as big as anywhere we display the photo) to save on storage space.

It also renders the images as squares everywhere